### PR TITLE
Fix link to Nginx Proxy Manager

### DIFF
--- a/administration/docker/multi-site-installation.md
+++ b/administration/docker/multi-site-installation.md
@@ -16,7 +16,7 @@ Follow the steps below to configure your installation for multisite support.
 
 # Nginx Proxy Manager
 
-Most users prefer to use a proxy manager that includes a GUI for easier management of the proxy. There are a lot of different tools for this one of which is the [Nginx Proxy Manager](/en/https://nginxproxymanager.com/) which uses NGINX and includes an easy to use GUI and automatic Let's Encrypt SSL which should be sufficient for most users.
+Most users prefer to use a proxy manager that includes a GUI for easier management of the proxy. There are a lot of different tools for this one of which is the [Nginx Proxy Manager](https://nginxproxymanager.com/) which uses NGINX and includes an easy to use GUI and automatic Let's Encrypt SSL which should be sufficient for most users.
 
 ## Enter AzuraCast Base Directory
 


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request to our repository!
All pull requests are automatically routed through our testing suite, which may identify issues with your
proposed changes; feel free to submit corrections as necessary to ensure those tests pass.

If you haven't already, please review our contributing guidelines at `CONTRIBUTING.md`.

If you have not already signed our Contributor License Agreement, a bot will reply to this pull request
once submitted with instructions on how to do so.
-->

**Fixes issue:** Currently, clicking on the link goes to the wrong URL, which results in 404.
<!-- GitHub issue number (i.e. #1234) of the issue this fixes, if applicable -->

**Proposed changes:** Change link to valid Nginx Proxy Manager URL.
<!-- A bulleted list summarizing the changes this pull request makes in simple language. -->
