### PR TITLE
notice about nginx_proxy

### DIFF
--- a/administration/docker/multi-site-installation.md
+++ b/administration/docker/multi-site-installation.md
@@ -172,7 +172,7 @@ cp docker-compose.override.yml docker-compose.override.bak.yml
 curl -fsSL https://raw.githubusercontent.com/AzuraCast/AzuraCast/master/docker-compose.multisite.yml > docker-compose.override.yml
 ```
 
-Note that if you've already set up an override file with other modifications, you should make sure to apply the same changes that are now located in `docker-compose.override.bak.yml` to the newly downloaded `docker-compose.override.yml` file.
+Note that if you've already set up an override file with other modifications, you should make sure to apply the same changes that are now located in `docker-compose.override.bak.yml` to the newly downloaded `docker-compose.override.yml` file. Also, if you are using "Rolling-Release", you may need to remove "nginx_proxy" service from `docker-compose.override.yml` to avoid errors during next steps.
 
 <br>
 

--- a/administration/docker/multi-site-installation.md
+++ b/administration/docker/multi-site-installation.md
@@ -270,5 +270,6 @@ networks:
 volumes:
     db_data: {}
 ```
-   
+_(Note, you might also need to change `azuracast_frontend` network to `azuracast_default` in newer Azuracast versions)_
+
 Once created and saved, you can spin up the new service by running `docker-compose up -d` in the same directory.

--- a/administration/docker/multi-site-installation.md
+++ b/administration/docker/multi-site-installation.md
@@ -237,7 +237,7 @@ services:
         restart: always
         ports:
         # Set any desired port for your wp service
-         - "8080:80"
+         - "8081:80"
         environment:
             # Change this to the domain your Wordpress site should be served on.
             VIRTUAL_HOST: wordpress.example.com
@@ -246,12 +246,12 @@ services:
             # LETSENCRYPT_EMAIL: youremail@example.com
             WORDPRESS_DB_HOST: db:3306
             # If you customize these values, make sure to customize them below also.
-            WORDPRESS_DB_USER: wordpress
-            WORDPRESS_DB_PASSWORD: wordpress
-            WORDPRESS_DB_NAME: wordpress
+            WORDPRESS_DB_USER: wordpress_user
+            WORDPRESS_DB_PASSWORD: wordpress_pass
+            WORDPRESS_DB_NAME: wordpress_db
 
     db:
-        image: mysql:5.7
+        image: mysql:8.0
         volumes:
          - db_data:/var/lib/mysql
         networks:
@@ -260,9 +260,9 @@ services:
         environment:
             # If you customize these values, make sure to customize them above also.
             MYSQL_ROOT_PASSWORD: somewordpress
-            MYSQL_DATABASE: wordpress
-            MYSQL_USER: wordpress
-            MYSQL_PASSWORD: wordpress
+            MYSQL_DATABASE: wordpress_db
+            MYSQL_USER: wordpress_user
+            MYSQL_PASSWORD: wordpress_pass
 
 networks:
     azuracast_frontend:
@@ -275,4 +275,4 @@ volumes:
 ```
 _(Note, you might also need to change `azuracast_frontend` network to `azuracast_default` in newer Azuracast versions)_
 
-Once created and saved, you can spin up the new service by running `docker-compose up -d` in the same directory.
+Once created and saved, you can spin up the new service by running `docker-compose up -d` in the same directory, and then in *Nginx Proxy Manager* map the example port `8081` to your sub/domain.

--- a/administration/docker/multi-site-installation.md
+++ b/administration/docker/multi-site-installation.md
@@ -235,6 +235,9 @@ services:
          - azuracast_frontend
          - backend
         restart: always
+        ports:
+        # Set any desired port for your wp service
+         - "8080:80"
         environment:
             # Change this to the domain your Wordpress site should be served on.
             VIRTUAL_HOST: wordpress.example.com

--- a/administration/docker/multi-site-installation.md
+++ b/administration/docker/multi-site-installation.md
@@ -172,7 +172,7 @@ cp docker-compose.override.yml docker-compose.override.bak.yml
 curl -fsSL https://raw.githubusercontent.com/AzuraCast/AzuraCast/master/docker-compose.multisite.yml > docker-compose.override.yml
 ```
 
-Note that if you've already set up an override file with other modifications, you should make sure to apply the same changes that are now located in `docker-compose.override.bak.yml` to the newly downloaded `docker-compose.override.yml` file. Also, if you are using "Rolling-Release", you may need to remove "nginx_proxy" service from `docker-compose.override.yml` to avoid errors during next steps.
+Note that if you've already set up an override file with other modifications, you should make sure to apply the same changes that are now located in `docker-compose.override.bak.yml` to the newly downloaded `docker-compose.override.yml` file. Also, if you are using "Rolling-Release", you may need to remove "nginx_proxy" and "nginx_proxy_letsencrypt"  service from `docker-compose.override.yml` to avoid errors during next steps.
 
 <br>
 


### PR DESCRIPTION
**Proposed changes:**
it shows `service "nginx_proxy" refers to undefined network frontend: invalid compose project` during `./docker.sh letsencrypt-create` or  `docker-compose up -d` . as [Vaalyn](https://github.com/AzuraCast/AzuraCast/issues/5078#issuecomment-1031365284) noted here, it is no longer needed for rolling versions.

